### PR TITLE
Patch 1

### DIFF
--- a/para-para/build.sh
+++ b/para-para/build.sh
@@ -9,7 +9,7 @@ ELDF=${ESDK}/bsps/current/internal.ldf
 export PATH=/usr/local/browndeer/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/browndeer/lib:/usr/local/lib:$LD_LIBRARY_PATH
 
-MPICC=/usr/local/bin/mpicc
+MPICC=/opt/openmpi/bin/mpicc
 
 # Build OpenMP
 gcc src/hello-openmp.c -fopenmp -o hello-openmp.elf

--- a/para-para/run.sh
+++ b/para-para/run.sh
@@ -2,7 +2,7 @@
 export PATH=/usr/local/browndeer/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/browndeer/lib:/usr/local/lib:$LD_LIBRARY_PATH
 #OpenMP
-MPIRUN=/usr/local/bin/mpirun
+MPIRUN=/opt/openmpi/bin/mpirun
 HOST=`hostname`
 echo -------------------------
 echo Running OpenMP Example


### PR DESCRIPTION
With a new (formatted sd card) containing:
ftp://ftp.parallella.org/ubuntu/dists/trusty/image/ubuntu-14.04-headless-z7020-20141110.img.gz
Running in my Kickstarter board, the para-para demos could not compile and run because the openmpi files are in /opt/openmpi and not /usr/local. These changes allowed the openmpi demos to run.

I cannot figure out the opencl situation. Nothing works for me.

Thanks for developing the parallella!
Bob Heacox 
