### PR TITLE
added a multicast example with light-weight hardware-barrier

### DIFF
--- a/multicast/LICENSE
+++ b/multicast/LICENSE
@@ -1,0 +1,176 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+

--- a/multicast/Makefile
+++ b/multicast/Makefile
@@ -1,0 +1,53 @@
+# 
+# Copyright 2015 Patrick D. M. Siegl
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+TARGET	:= main.elf e_main.srec
+default: $(TARGET)
+
+DEPS := $(shell ls .dep_*)
+-include $(DEPS)
+
+## ACC  #################
+C_PERF := -O3
+C_SIZE := -ffunction-sections -fdata-sections
+e_%.o: e_%.c
+	e-gcc ${C_PERF} ${C_SIZE} -Wall -Wunused-variable -MMD -MF".dep_$@.d" -c -o $@ $<
+
+L_SIZE := -Wl,-static -Wl,-s -Wl,--gc-sections
+e_%.elf: e_%.o
+	e-gcc -T $(EPIPHANY_HOME)/bsps/current/internal.ldf ${L_SIZE} -o $@ $< -le-lib
+	@e-size $@
+
+e_%.srec: e_%.elf
+	e-objcopy --srec-forceS3 --output-target srec $^ $@
+
+## HOST #################
+%.elf: %.o
+	gcc -L ${EPIPHANY_HOME}/tools/host.armv7l/lib -o $@ $< -lm -le-hal -le-loader
+	@size $@
+
+%.o: %.c
+	gcc -O3 -mfpu=neon -I $(EPIPHANY_HOME)/tools/host.armv7l/include -MMD -MF".dep_$@.d" -c -o $@ $<
+
+## RUN  #################
+ELIBS=${ESDK}/tools/host.armv7l/lib:${LD_LIBRARY_PATH}
+EHDF=${EPIPHANY_HDF}
+run: $(TARGET)
+	sudo -E LD_LIBRARY_PATH=${ELIBS} EPIPHANY_HDF=${EHDF} ./main.elf
+
+
+clean:
+	rm -rf $(TARGET) .dep* *.o *.elf *.log

--- a/multicast/README
+++ b/multicast/README
@@ -1,0 +1,24 @@
+This project offers an example to utilize the hardware multicast
+facility via regular load/stores of the Adapteva Epiphany accelerator.
+To this, faster methods are available, which can read the status,
+config and timer registers without any overhead of method calling
+(compared to the default epiphany library).
+Last, an barrier was implemented, able to utilize the hardware barrier
+capability.
+
+Contains:
+- light-weight implementation of the hardware barrier
+- light-weight inline-methods for the config/status/counter registers
+- ... and as descriped, the support of the multicast
+
+Minor issue:
+- The example is optimized for the 16 core version, but can also be
+  modified to run on the 64 core variant (see config_t.h, also
+  e_methods.h -> get_remote_ptr needs to be modified!)
+
+Mayor issue:
+- The hardware multicast can only be issued by the cores of the first
+  column (0, 1, 2, 3), otherwise a hardware bug is triggered, leading
+  to a freeze of the application! This is a known issue of the Epiphany
+  III chip.
+  See also: http://forums.parallella.org/viewtopic.php?f=9&t=650#p4087

--- a/multicast/b_hw.h
+++ b/multicast/b_hw.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2015 Patrick D. M. Siegl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "config_t.h"
+#include "e_methods.h"
+
+#define WAND_BIT (1 << 3)
+
+static void __attribute__((interrupt)) wand_isr( int signum )
+{
+}
+
+void hw_barrier_init( void ) {
+  e_irq_global_mask( E_FALSE );
+  e_irq_attach( WAND_BIT, wand_isr );
+  e_irq_mask( WAND_BIT, E_FALSE );
+}
+
+ALWAYS_INLINE void hw_barrier( void ) {
+  __asm__ __volatile__("wand");
+  __asm__ __volatile__("idle");
+
+  unsigned irq_state = _e_reg_read_status();
+  irq_state &= ~WAND_BIT;
+  _e_reg_write_status( irq_state ); // clear wand bit
+}

--- a/multicast/config_t.h
+++ b/multicast/config_t.h
@@ -1,0 +1,33 @@
+//
+// Copyright 2015 Patrick D. M. Siegl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef _E_CONFIG_T_H_
+#define _E_CONFIG_T_H_
+
+#define _ROW_CORES    4
+#define _COL_CORES    4
+#define _NUM_CORES    (_ROW_CORES * _COL_CORES)
+
+typedef struct _mbox_t mbox_t;
+struct _mbox_t {
+  volatile unsigned ready;
+  volatile unsigned go;
+  volatile unsigned clocks[ _NUM_CORES ];
+};
+
+#define ALWAYS_INLINE inline __attribute__((always_inline))
+
+#endif /* #ifndef _E_CONFIG_T_H_ */

--- a/multicast/e_main.c
+++ b/multicast/e_main.c
@@ -1,0 +1,97 @@
+//
+// Copyright 2015 Patrick D. M. Siegl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <e-lib.h>
+#include "config_t.h"
+#include "e_methods.h"
+#include "b_hw.h"
+
+volatile unsigned test;
+
+int main( void ) {
+  test = 0;
+
+  e_ctimer_set(E_CTIMER_0, E_CTIMER_MAX);
+
+  unsigned c_id = e_group_config.core_row * e_group_config.group_cols + e_group_config.core_col;
+
+  hw_barrier_init();
+
+  mbox_t * mbox = (mbox_t *) e_emem_config.base;
+  mbox->ready = 1;
+  if( ! c_id ) {
+    mbox->ready = 1;
+    while( ! mbox->go );
+    mbox->ready = 0;
+  }
+
+  e_ctimer_start(E_CTIMER_0, E_CTIMER_CLK);
+
+/*
+  Multicast register
+
+  MULTICAST: 0xF0704 // <- manual is wrong!
+  Bits      Name           Function
+  [11:0]    MULTICAST_ID   ID to match to destination address[31:20] in the case of an incoming multicast write transaction
+  [31:12]   RESERVED       N/A
+
+        E_REG_COREID            = 0xf0704,
+        E_REG_MULTICAST         = 0xf0708,
+*/
+
+  // set for all the capability to recognize a multicast with id 1 << 11
+  unsigned multicast_id = 1 << 11; // push it to the top, so that it does not interfear with regular ld/st to mesh
+  unsigned * multicast_reg = ((unsigned*) get_remote_ptr( c_id, (void*) 0xF0708 /* E_REG_MULTICAST */ ));
+  unsigned multicast_original = *multicast_reg;
+  *multicast_reg = multicast_id;
+  volatile unsigned * p_test = (volatile unsigned *)(multicast_id << 20 | (unsigned) &test);
+
+  unsigned reg_cfg = 0;
+  if( ! c_id ) { /* does only work for 0,1,2,3 */
+    // read current config register and set c_id wants to send a MULTICAST
+    reg_cfg = _e_reg_read_config();
+    unsigned reg_cfg_mmr = ((~(0xF << 12)) & reg_cfg) | (0x3 << 12);
+    _e_reg_write_config( reg_cfg_mmr );
+  }
+
+  hw_barrier();
+
+// -------------- test ----------------------
+  unsigned time_start = _e_get_ctimer0();
+  if( ! c_id ) {
+    *p_test = 1; // this will be broadcasted as multicast
+  }
+  else {
+    while( ! test ); // listening for multicast
+  }
+  unsigned time_end = _e_get_ctimer0();
+// -------------- test ----------------------
+
+  if( ! c_id )
+    _e_reg_write_config( reg_cfg );
+  *multicast_reg = multicast_original;
+
+  mbox->clocks[ c_id ] = time_start - time_end; // parallella is ticking down
+
+  hw_barrier();
+
+  if( ! c_id ) {
+    mbox->go    = 0;
+    mbox->ready = 1;
+  }
+
+  return 0;
+}

--- a/multicast/e_methods.h
+++ b/multicast/e_methods.h
@@ -1,0 +1,65 @@
+//
+// Copyright 2015 Patrick D. M. Siegl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef _E_METHODS_H_
+#define _E_METHODS_H_
+
+#include <e-lib.h> // e_group_config, e_ctimer_set(), e_ctimer_start()
+
+ALWAYS_INLINE unsigned _e_get_ctimer0()
+{
+  register unsigned tmp asm("r0");
+  asm volatile ("movfs %0, ctimer0;" : "=r" (tmp) :: );
+  return tmp;
+}
+
+ALWAYS_INLINE unsigned _e_reg_read_config( void )
+{
+  register unsigned tmp asm("r0");
+  asm volatile ("movfs %0, config;" : "=r" (tmp) :: );
+  return tmp;
+}
+
+ALWAYS_INLINE void _e_reg_write_config( register unsigned val )
+{
+  asm volatile ("movts config, %0;" :: "r" (val) : );
+}
+
+ALWAYS_INLINE unsigned _e_reg_read_status( void )
+{
+  register unsigned tmp asm("r0");
+  asm volatile ("movfs %0, status;" : "=r" (tmp) :: );
+  return tmp;
+}
+
+ALWAYS_INLINE void _e_reg_write_status( register unsigned val )
+{
+  asm volatile ("movts status, %0;" :: "r" (val) : );
+}
+
+
+unsigned * get_remote_ptr( unsigned id, void * ptr ) {
+// --------------------------------------------
+// needs to be adjusted for the 64 core version
+  unsigned col_id = id & 0x3;
+  unsigned row_id = id >> 2;
+  unsigned core_id = (row_id * 0x40 + col_id) + e_group_config.group_id;
+// --------------------------------------------
+  unsigned * new_ptr = (unsigned *)((core_id << 20) | (unsigned)ptr);
+  return new_ptr;
+}
+
+#endif /* #ifndef _E_METHODS_H_ */

--- a/multicast/main.c
+++ b/multicast/main.c
@@ -1,0 +1,104 @@
+//
+// Copyright 2015 Patrick D. M. Siegl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <e-loader.h>
+#include "e-hal.h"
+#include "config_t.h"
+
+typedef struct _e_info_t e_info_t;
+struct _e_info_t {
+  e_epiphany_t Epiphany;
+  e_mem_t DRAM;
+  mbox_t * mbox;
+};
+
+#define MB( x ) ( (x)*1024*1024 )
+
+extern e_platform_t e_platform;
+void epiphany_init( e_info_t * e_info )
+{
+  e_init(NULL);
+  e_reset_system();
+
+  if (e_open(&e_info->Epiphany, 0, 0, e_platform.chip[0].rows, e_platform.chip[0].cols)) {
+    printf( "\nERROR: Can't establish connection to Epiphany device!\n\n");
+    exit(1);
+  }
+  if (e_alloc(&e_info->DRAM, 0x00000000, MB(32))) {
+    printf( "\nERROR: Can't allocate Epiphany DRAM!\n\n");
+    exit(1);
+  }
+  e_info->mbox = (mbox_t * )e_info->DRAM.base;
+  memset( (void*)e_info->mbox, 0, MB(32) );
+
+  e_reset_group(&e_info->Epiphany);
+
+  if (e_load_group("e_main.srec", &e_info->Epiphany, 0, 0, 4, 4, E_FALSE ) == E_ERR) {
+    printf( "\nERROR: loading Epiphany program.\n");
+    exit(1);
+  }
+
+}
+
+void epiphany_finalize( e_info_t * e_info )
+{
+  // Close connection to device
+  if (e_close(&e_info->Epiphany)) {
+    printf( "\nERROR: Can't close connection to Epiphany device!\n\n");
+    exit(1);
+  }
+  if (e_free(&e_info->DRAM)) {
+    printf( "\nERROR: Can't release Epiphany DRAM!\n\n");
+    exit(1);
+  }
+
+  e_finalize();
+}
+
+
+int main( int argc, char * argv[] )
+{
+  e_info_t e_info;
+  epiphany_init( &e_info );
+
+  mbox_t * mbox = e_info.mbox;
+  mbox->ready = 0;
+  mbox->go = 0;
+
+  e_start_group( &e_info.Epiphany ); // start epiphany
+
+  printf( "start initialization\n" );
+  while( ! mbox->ready ); // check if epiphany is ready
+
+  printf( "start massive computation\n\n" );
+  mbox->go = 1; // let cores run!
+  while( mbox->go );
+
+  epiphany_finalize( &e_info );
+
+  unsigned i, sum = 0;
+  for( i = 0; i < _NUM_CORES; i++ ) {
+    printf("core %2d lat.: %2d cycles\n", i, mbox->clocks[i] );
+    sum += mbox->clocks[i];
+  }
+
+  printf("\nMulticast average overhead: %d cycles\n\n", sum / _NUM_CORES );
+
+  return 0;
+}


### PR DESCRIPTION
added a multicast example with light-weight hardware-barrier and light-weight in-line status/config/counter retrieve methods for the 16 core Epiphany. The 64 core Epiphany requires some little and simple changes