### PR TITLE
eprime: Format the console so that the test status writes in position

### DIFF
--- a/eprime/src/prime.c
+++ b/eprime/src/prime.c
@@ -74,11 +74,21 @@ int main(int argc, char *argv[])
 	uint64_t total_primes = 0;
 	uint64_t last = 0;
 
+	// line-count for formatting the console output without paging
+	const unsigned linecount = (platform.rows * platform.cols) + 2;
+
+	// Make some empty space for the output to display
+	for (row=0; row < linecount; row++)
+		fputs("\n", stderr);
+
 	while(1)
 	{
 		sum = 0;
 		total_primes = 0;
 		usleep(100000);
+
+		// Reset the cursor position every iteration
+		fprintf(stderr, "\e[%dA", linecount);
 
 		// Read the stats values from each core
 		for(row=0;row<platform.rows;row++)


### PR DESCRIPTION
With this patch, the output of the eprime test will overwrite the same lines (barring any newlines added by the user in the terminal) instead of appending to the console output. It gives the output a more dashboard-like feeling.

I normally would not use ANSI codes directly, but, this is the best I could do without ncurses installed on the Parallella Ubuntu image.