### PR TITLE
eprime: add check for odd numbers

### DIFF
--- a/eprime/src/isprime.c
+++ b/eprime/src/isprime.c
@@ -23,6 +23,10 @@ inline int isprime(unsigned long number)
 {
 	unsigned long i;
 	unsigned long s = sqrt(number);
+	if(number > 2 && number % 2 == 0)
+	{
+        	return 0;
+    	}
 	for(i=3;i<=s;i+=2)
 	{
 		if(number % i == 0)


### PR DESCRIPTION
Found some code of a test parallella vs .. and they just did copy and paste this code.

ie:
https://github.com/RayHightower/parallella-primes/blob/master/primes-serial.c

So I think is fair just add a check for odd numbers.

did submit a PR to that code, but this will help for other people wanting to do the same