### PR TITLE
Fix the lana example to work with the SDK.2015.1

### DIFF
--- a/lena/build.sh
+++ b/lena/build.sh
@@ -61,6 +61,7 @@ ${CROSS_PREFIX}g++ \
 	-o "./host/${Config}/fft2d_host.elf" \
 	"./host/src/fft2d_host.c" \
 	-le-hal \
+	-le-loader \
 	-lIL \
 	-lILU \
 	-lILUT \

--- a/lena/host/src/fft2d_host.c
+++ b/lena/host/src/fft2d_host.c
@@ -61,6 +61,7 @@
 
 typedef unsigned int e_coreid_t;
 #include <e-hal.h>
+#include <e-loader.h>
 #include "fft2dlib.h"
 #include "fft2d.h"
 #include "dram_buffers.h"


### PR DESCRIPTION
Link e-loader and include the header.